### PR TITLE
fix: Correct physics initialization for Player class

### DIFF
--- a/js/Player.js
+++ b/js/Player.js
@@ -3,9 +3,9 @@ import Bullet from './Bullet.js';
 export default class Player extends Phaser.GameObjects.Sprite {
     constructor(scene, x, y, texture) {
         super(scene, x, y, texture);
-        // scene.add.existing(this); // Removed redundant call
-        // scene.physics.add.existing(this); // Removed redundant call
-        this.setCollideWorldBounds(true);
+        scene.add.existing(this); // Add to display list
+        scene.physics.add.existing(this); // Add to physics system, creates this.body
+        this.setCollideWorldBounds(true); // Now this.body exists
 
         this.score = 0;
         this.health = 100;


### PR DESCRIPTION
The Player class extends `Phaser.GameObjects.Sprite`, which requires explicit steps to be enabled in the physics system. A previous fix incorrectly removed these necessary steps, leading to a TypeError when `this.setCollideWorldBounds(true)` was called because `this.body` was not yet created.

This commit reinstates the correct initialization sequence in the `Player.js` constructor:
1. `super(scene, x, y, texture);`
2. `scene.add.existing(this);` (to add to the display list)
3. `scene.physics.add.existing(this);` (to enable physics and create `this.body`)

This ensures that `this.body` is available before any methods that depend on it (like `setCollideWorldBounds`) are called, resolving the "this.setCollideWorldBounds is not a function" error.