### PR TITLE
refactor: Use scene.physics.world.enable for Player physics

### DIFF
--- a/js/Player.js
+++ b/js/Player.js
@@ -4,8 +4,8 @@ export default class Player extends Phaser.GameObjects.Sprite {
     constructor(scene, x, y, texture) {
         super(scene, x, y, texture);
         scene.add.existing(this); // Add to display list
-        scene.physics.add.existing(this); // Add to physics system, creates this.body
-        this.setCollideWorldBounds(true); // Now this.body exists
+        scene.physics.world.enable(this); // Enable physics body using world.enable
+        this.setCollideWorldBounds(true); // Now this.body should exist
 
         this.score = 0;
         this.health = 100;


### PR DESCRIPTION
Changed the method for enabling physics on the Player sprite in its constructor. Instead of `scene.physics.add.existing(this)`, the code now uses `scene.physics.world.enable(this)` after the sprite has been added to the display list via `scene.add.existing(this)`.

This is a standard way to enable a physics body on an existing Phaser.GameObjects.Sprite instance.

This change is an attempt to resolve a persistent TypeError related to `scene.physics` or its properties being undefined during Player construction. If the issue persists, it may indicate a problem with the MainScene's physics configuration rather than the method of enabling physics on the Player sprite itself.