### PR TITLE
fix: Add global physics configuration to game.js

### DIFF
--- a/game.js
+++ b/game.js
@@ -4,7 +4,14 @@ const config = {
     type: Phaser.AUTO,
     width: 800,
     height: 600,
-    scene: [MainScene]
+    scene: [MainScene],
+    physics: {
+        default: 'arcade',
+        arcade: {
+            // gravity: { y: 0 }, // Example: no global gravity
+            debug: false // Set to true for physics debugging
+        }
+    }
 };
 
 const game = new Phaser.Game(config);


### PR DESCRIPTION
Resolves persistent TypeErrors in Player.js (e.g., "Cannot read properties of undefined (reading 'world')") which occurred because `scene.physics` was undefined.

The root cause was the absence of a physics system configuration for MainScene. This commit adds a global Arcade Physics configuration to the `Phaser.Game` config object in `game.js`.

This ensures that MainScene, and any other scenes, will have the Arcade Physics system initialized and available via `scene.physics`, allowing physics operations on game objects to succeed.