### PR TITLE
feat: Add console logs to Player constructor for debugging

### DIFF
--- a/js/Player.js
+++ b/js/Player.js
@@ -2,9 +2,14 @@ import Bullet from './Bullet.js';
 
 export default class Player extends Phaser.GameObjects.Sprite {
     constructor(scene, x, y, texture) {
+        console.log("Player Constructor - Scene Physics:", scene.physics);
+        console.log("Player Constructor - Scene Physics World:", scene.physics.world);
+
         super(scene, x, y, texture);
         scene.add.existing(this); // Add to display list
         scene.physics.world.enable(this); // Enable physics body using world.enable
+
+        console.log("Player body before setCollideWorldBounds:", this.body); // New log
         this.setCollideWorldBounds(true); // Now this.body should exist
 
         this.score = 0;


### PR DESCRIPTION
I've added console.log statements in js/Player.js to output:
- scene.physics
- scene.physics.world
- this.body (before setCollideWorldBounds)

This is to help diagnose the persistent TypeError occurring when `this.setCollideWorldBounds(true)` is called, by inspecting the state of these critical objects at runtime.