### PR TITLE
refactor: Change Player to extend Phaser.Physics.Arcade.Sprite

### DIFF
--- a/js/Player.js
+++ b/js/Player.js
@@ -1,16 +1,15 @@
 import Bullet from './Bullet.js';
 
-export default class Player extends Phaser.GameObjects.Sprite {
+// Changed to extend Phaser.Physics.Arcade.Sprite
+export default class Player extends Phaser.Physics.Arcade.Sprite {
     constructor(scene, x, y, texture) {
-        console.log("Player Constructor - Scene Physics:", scene.physics);
-        console.log("Player Constructor - Scene Physics World:", scene.physics.world);
+        // Debugging logs removed
+        super(scene, x, y, texture); // Handles adding to scene and physics
 
-        super(scene, x, y, texture);
-        scene.add.existing(this); // Add to display list
-        scene.physics.world.enableBody(this, Phaser.Physics.Arcade.DYNAMIC_BODY); // Changed line
+        // Manual add.existing and physics.world.enableBody removed
+        // Debugging log for this.body removed
 
-        console.log("Player body after enableBody:", this.body, "Type:", typeof this.body); // Updated log
-        this.setCollideWorldBounds(true); // Now this.body should exist
+        this.setCollideWorldBounds(true); // this.body is created by super()
 
         this.score = 0;
         this.health = 100;


### PR DESCRIPTION
To resolve persistent TypeErrors related to `this.body` not being correctly initialized, I've updated the Player class in `js/Player.js` so it now extends `Phaser.Physics.Arcade.Sprite` instead of `Phaser.GameObjects.Sprite`.

This change simplifies the Player constructor significantly:
- The `super(scene, x, y, texture);` call now handles adding the sprite to both the display list and the physics world, and it also creates the physics body (`this.body`).
- Manual calls to `scene.add.existing(this)` and any form of `scene.physics.world.enable()` or `scene.physics.add.existing()` have been removed as they are no longer necessary.
- All debugging console.log statements have been removed from the constructor.

This is a more robust and standard Phaser approach for sprites that are inherently physics-based, and it is expected to definitively resolve the `this.setCollideWorldBounds is not a function` error.