### PR TITLE
feat: Add focused log for this.body after super() in Player

### DIFF
--- a/js/Player.js
+++ b/js/Player.js
@@ -3,13 +3,9 @@ import Bullet from './Bullet.js';
 // Changed to extend Phaser.Physics.Arcade.Sprite
 export default class Player extends Phaser.Physics.Arcade.Sprite {
     constructor(scene, x, y, texture) {
-        // Debugging logs removed
         super(scene, x, y, texture); // Handles adding to scene and physics
-
-        // Manual add.existing and physics.world.enableBody removed
-        // Debugging log for this.body removed
-
-        this.setCollideWorldBounds(true); // this.body is created by super()
+        console.log("Player body AFTER super():", this.body, "Type:", typeof this.body); // New focused log
+        this.setCollideWorldBounds(true); // Line that causes error
 
         this.score = 0;
         this.health = 100;


### PR DESCRIPTION
To further diagnose why `this.body` might be null when Player extends Phaser.Physics.Arcade.Sprite:
- I've added a console.log statement immediately after `super()` in the Player constructor to inspect `this.body` and its type.
- I've ensured the Player class extends Phaser.Physics.Arcade.Sprite.
- I've removed older debugging logs.